### PR TITLE
Add English and Korean localization

### DIFF
--- a/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
+++ b/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
@@ -32,7 +32,7 @@ public class MainActivity extends AppCompatActivity {
             runOnUiThread(() -> {
                 Toast.makeText(
                         MainActivity.this,
-                        "请先激活模块",
+                        R.string.message_activate_module_first,
                         Toast.LENGTH_LONG
                 ).show();
             });
@@ -58,7 +58,7 @@ public class MainActivity extends AppCompatActivity {
         // 手势选择
         ArrayAdapter<String> adapterGesture = new ArrayAdapter<>(
                 this, android.R.layout.simple_spinner_item,
-                new String[]{"短按", "双击", "长按"}
+                getResources().getStringArray(R.array.gesture_options)
         );
         adapterGesture.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinnerGesture.setAdapter(adapterGesture);
@@ -66,14 +66,14 @@ public class MainActivity extends AppCompatActivity {
         // 类型选择
         ArrayAdapter<String> adapterType = new ArrayAdapter<>(
                 this, android.R.layout.simple_spinner_item,
-                new String[]{"无", "常用功能", "执行小布快捷指令", "自定义Activity", "自定义UrlScheme", "自定义Shell命令"}
+                getResources().getStringArray(R.array.type_options)
         );
         adapterType.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinnerType.setAdapter(adapterType);
 
         ArrayAdapter<String> adapterCommon = new ArrayAdapter<>(
                 this, android.R.layout.simple_spinner_item,
-                new String[]{"微信付款码", "微信扫一扫", "支付宝付款码", "支付宝扫一扫", "云闪付付款码", "云闪付扫一扫", "一键闪记", "小布记忆"}
+                getResources().getStringArray(R.array.common_action_options)
         );
         adapterCommon.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinnerCommon.setAdapter(adapterCommon);
@@ -109,7 +109,7 @@ public class MainActivity extends AppCompatActivity {
     private void loadGestureConfig(int gesture) {
         String prefix = getPrefix(gesture);
 
-        spinnerType.setSelection(getTypeIndex(SPUtils.getString(prefix + "type", "无")));
+        spinnerType.setSelection(getTypeIndex(SPUtils.getString(prefix + "type", getTypeValue(0))));
         spinnerCommon.setSelection(SPUtils.getInt(prefix + "common_index", 0));
 
         editPackage.setText(SPUtils.getString(prefix + "package", ""));
@@ -128,7 +128,7 @@ public class MainActivity extends AppCompatActivity {
         int gesture = spinnerGesture.getSelectedItemPosition();
         String prefix = getPrefix(gesture);
 
-        SPUtils.putString(prefix + "type", (String) spinnerType.getSelectedItem());
+        SPUtils.putString(prefix + "type", getTypeValue(spinnerType.getSelectedItemPosition()));
         SPUtils.putInt(prefix + "common_index", spinnerCommon.getSelectedItemPosition());
         SPUtils.putString(prefix + "package", editPackage.getText().toString().trim());
         SPUtils.putString(prefix + "activity", editActivity.getText().toString().trim());
@@ -139,14 +139,14 @@ public class MainActivity extends AppCompatActivity {
         SPUtils.putBoolean(prefix + "vibrate", checkboxVibrate.isChecked());
         SPUtils.putBoolean(prefix + "screen_off", checkboxExecuteWhenScreenOff.isChecked());
 
-        Toast.makeText(this, "已保存（3 秒后生效）", Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, R.string.message_saved, Toast.LENGTH_SHORT).show();
 
-        String type = (String) spinnerType.getSelectedItem();
+        String type = getTypeValue(spinnerType.getSelectedItemPosition());
         if (type.equals("自定义Shell命令")) {
             if (applyRootPermission()) {
-                Toast.makeText(this, "已被授予Root权限", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.message_root_granted, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "已被拒绝Root权限，无法执行Shell命令", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.message_root_denied, Toast.LENGTH_SHORT).show();
             }
             showShellPermissionDialog();
         }
@@ -181,6 +181,23 @@ public class MainActivity extends AppCompatActivity {
                 return 5;
             default:
                 return 0;
+        }
+    }
+
+    private String getTypeValue(int index) {
+        switch (index) {
+            case 1:
+                return "常用功能";
+            case 2:
+                return "执行小布快捷指令";
+            case 3:
+                return "自定义Activity";
+            case 4:
+                return "自定义UrlScheme";
+            case 5:
+                return "自定义Shell命令";
+            default:
+                return "无";
         }
     }
 
@@ -227,14 +244,14 @@ public class MainActivity extends AppCompatActivity {
 
     private void showShellPermissionDialog() {
         new AlertDialog.Builder(this)
-                .setTitle("提示")
-                .setMessage("由于系统限制，执行Shell命令需要Root权限和自启动权限，否则无法执行。\n应用只会在执行命令的瞬间启动，执行完毕后自动退出，不会占用后台内存。\n在某些情况下，你可能还需要在应用详情的耗电管理中完全允许后台行为。")
+                .setTitle(R.string.dialog_title_notice)
+                .setMessage(R.string.dialog_shell_permission_message)
                 .setCancelable(false)
-                .setNegativeButton("去授权", (dialog, which) -> {
+                .setNegativeButton(R.string.action_authorize, (dialog, which) -> {
                     // 继续执行跳转逻辑
                     gotoColorOSAutoStart();        // 自启动管理
                 })
-                .setPositiveButton("确定", null)
+                .setPositiveButton(R.string.action_confirm, null)
                 .show();
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:layout_marginBottom="8dp"
-            android:text="选择事件类型"
+            android:text="@string/label_gesture_type"
             android:textSize="16sp" />
 
         <Spinner
@@ -27,7 +27,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="8dp"
-            android:text="选择快捷键功能"
+            android:text="@string/label_action_type"
             android:textSize="16sp" />
 
         <Spinner
@@ -47,7 +47,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="选择常用功能" />
+                android:text="@string/label_common_action" />
 
             <Spinner
                 android:id="@+id/spinnerCommon"
@@ -67,25 +67,25 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="包名" />
+                android:text="@string/label_package_name" />
 
             <EditText
                 android:id="@+id/editPackage"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：com.coolapk.market" />
+                android:hint="@string/hint_package_name" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="Activity" />
+                android:text="@string/label_activity" />
 
             <EditText
                 android:id="@+id/editActivity"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：com.coolapk.market.view.search.SuperSearchActivity" />
+                android:hint="@string/hint_activity" />
         </LinearLayout>
 
         <!-- 自定义 URL Scheme -->
@@ -100,13 +100,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="URL Scheme" />
+                android:text="@string/label_url_scheme" />
 
             <EditText
                 android:id="@+id/editUrlScheme"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：weixin://" />
+                android:hint="@string/hint_url_scheme" />
         </LinearLayout>
 
         <!-- 快捷指令ID -->
@@ -121,13 +121,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="小布快捷指令ID" />
+                android:text="@string/label_xiaobu_shortcut_id" />
 
             <EditText
                 android:id="@+id/editxiaobuShortcuts"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="抓取ID后，粘贴在这里" />
+                android:hint="@string/hint_xiaobu_shortcut_id" />
         </LinearLayout>
 
         <!-- 快捷指令ID -->
@@ -142,13 +142,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Shell命令" />
+                android:text="@string/label_shell_command" />
 
             <EditText
                 android:id="@+id/editShell"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="输入要执行的命令" />
+                android:hint="@string/hint_shell_command" />
         </LinearLayout>
 
         <CheckBox
@@ -157,7 +157,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:checked="true"
-            android:text="是否震动反馈" />
+            android:text="@string/label_vibrate_feedback" />
 
         <CheckBox
             android:id="@+id/checkboxExecuteWhenScreenOff"
@@ -165,13 +165,13 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"
             android:checked="true"
-            android:text="息屏状态下是否执行操作" />
+            android:text="@string/label_execute_when_screen_off" />
 
         <Button
             android:id="@+id/btnSave"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="保存设置" />
+            android:text="@string/action_save" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-en/array.xml
+++ b/app/src/main/res/values-en/array.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="gesture_options">
+        <item>Single press</item>
+        <item>Double press</item>
+        <item>Long press</item>
+    </string-array>
+
+    <string-array name="type_options">
+        <item>None</item>
+        <item>Common action</item>
+        <item>Run Breeno shortcut</item>
+        <item>Custom Activity</item>
+        <item>Custom URL Scheme</item>
+        <item>Custom Shell command</item>
+    </string-array>
+
+    <string-array name="common_action_options">
+        <item>WeChat payment code</item>
+        <item>WeChat scan</item>
+        <item>Alipay payment code</item>
+        <item>Alipay scan</item>
+        <item>UnionPay payment code</item>
+        <item>UnionPay scan</item>
+        <item>Quick note</item>
+        <item>Breeno memory</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Shortcut Customization</string>
+    <string name="label_gesture_type">Select event type</string>
+    <string name="label_action_type">Select shortcut action</string>
+    <string name="label_common_action">Select common action</string>
+    <string name="label_package_name">Package name</string>
+    <string name="label_activity">Activity</string>
+    <string name="label_url_scheme">URL Scheme</string>
+    <string name="label_xiaobu_shortcut_id">Breeno shortcut ID</string>
+    <string name="label_shell_command">Shell command</string>
+    <string name="label_vibrate_feedback">Vibration feedback</string>
+    <string name="label_execute_when_screen_off">Run when screen is off</string>
+    <string name="action_save">Save settings</string>
+    <string name="action_authorize">Authorize</string>
+    <string name="action_confirm">OK</string>
+    <string name="hint_package_name">Example: com.coolapk.market</string>
+    <string name="hint_activity">Example: com.coolapk.market.view.search.SuperSearchActivity</string>
+    <string name="hint_url_scheme">Example: weixin://</string>
+    <string name="hint_xiaobu_shortcut_id">Paste the captured ID here</string>
+    <string name="hint_shell_command">Enter the command to execute</string>
+    <string name="message_activate_module_first">Please activate the module first</string>
+    <string name="message_saved">Saved (takes effect in 3 seconds)</string>
+    <string name="message_root_granted">Root permission granted</string>
+    <string name="message_root_denied">Root permission denied, shell commands cannot run</string>
+    <string name="dialog_title_notice">Notice</string>
+    <string name="dialog_shell_permission_message">Because of system restrictions, running shell commands requires both root permission and auto-start permission.\nThe app only starts when the command runs and exits automatically afterwards, so it will not stay in memory.\nIn some cases, you may also need to fully allow background activity in the battery settings.</string>
+</resources>

--- a/app/src/main/res/values-ko/array.xml
+++ b/app/src/main/res/values-ko/array.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="gesture_options">
+        <item>짧게 누르기</item>
+        <item>두 번 누르기</item>
+        <item>길게 누르기</item>
+    </string-array>
+
+    <string-array name="type_options">
+        <item>없음</item>
+        <item>일반 기능</item>
+        <item>Breeno 단축 명령 실행</item>
+        <item>Custom Activity</item>
+        <item>Custom URL Scheme</item>
+        <item>Custom Shell 명령</item>
+    </string-array>
+
+    <string-array name="common_action_options">
+        <item>WeChat 결제 코드</item>
+        <item>WeChat 스캔</item>
+        <item>Alipay 결제 코드</item>
+        <item>Alipay 스캔</item>
+        <item>UnionPay 결제 코드</item>
+        <item>UnionPay 스캔</item>
+        <item>빠른 메모</item>
+        <item>Breeno 메모리</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">단축키 사용자 지정</string>
+    <string name="label_gesture_type">이벤트 유형 선택</string>
+    <string name="label_action_type">단축키 기능 선택</string>
+    <string name="label_common_action">일반 기능 선택</string>
+    <string name="label_package_name">패키지 이름</string>
+    <string name="label_activity">Activity</string>
+    <string name="label_url_scheme">URL Scheme</string>
+    <string name="label_xiaobu_shortcut_id">Breeno 단축 명령 ID</string>
+    <string name="label_shell_command">Shell 명령</string>
+    <string name="label_vibrate_feedback">진동 피드백</string>
+    <string name="label_execute_when_screen_off">화면이 꺼져 있을 때 실행</string>
+    <string name="action_save">설정 저장</string>
+    <string name="action_authorize">권한 설정</string>
+    <string name="action_confirm">확인</string>
+    <string name="hint_package_name">예: com.coolapk.market</string>
+    <string name="hint_activity">예: com.coolapk.market.view.search.SuperSearchActivity</string>
+    <string name="hint_url_scheme">예: weixin://</string>
+    <string name="hint_xiaobu_shortcut_id">캡처한 ID를 여기에 붙여넣으세요</string>
+    <string name="hint_shell_command">실행할 명령을 입력하세요</string>
+    <string name="message_activate_module_first">먼저 모듈을 활성화하세요</string>
+    <string name="message_saved">저장됨 (3초 후 적용)</string>
+    <string name="message_root_granted">Root 권한이 부여되었습니다</string>
+    <string name="message_root_denied">Root 권한이 거부되어 Shell 명령을 실행할 수 없습니다</string>
+    <string name="dialog_title_notice">안내</string>
+    <string name="dialog_shell_permission_message">시스템 제한으로 인해 Shell 명령을 실행하려면 Root 권한과 자동 시작 권한이 모두 필요합니다.\n앱은 명령을 실행하는 순간에만 시작되고 완료 후 자동으로 종료되므로 백그라운드 메모리를 차지하지 않습니다.\n경우에 따라 배터리 설정에서 백그라운드 동작을 완전히 허용해야 할 수도 있습니다.</string>
+</resources>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -4,4 +4,30 @@
         <item>android</item>
         <item>com.coloros.shortcuts</item>
     </string-array>
+
+    <string-array name="gesture_options">
+        <item>短按</item>
+        <item>双击</item>
+        <item>长按</item>
+    </string-array>
+
+    <string-array name="type_options">
+        <item>无</item>
+        <item>常用功能</item>
+        <item>执行小布快捷指令</item>
+        <item>自定义Activity</item>
+        <item>自定义UrlScheme</item>
+        <item>自定义Shell命令</item>
+    </string-array>
+
+    <string-array name="common_action_options">
+        <item>微信付款码</item>
+        <item>微信扫一扫</item>
+        <item>支付宝付款码</item>
+        <item>支付宝扫一扫</item>
+        <item>云闪付付款码</item>
+        <item>云闪付扫一扫</item>
+        <item>一键闪记</item>
+        <item>小布记忆</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,27 @@
 <resources>
     <string name="app_name">快捷键自定义</string>
+    <string name="label_gesture_type">选择事件类型</string>
+    <string name="label_action_type">选择快捷键功能</string>
+    <string name="label_common_action">选择常用功能</string>
+    <string name="label_package_name">包名</string>
+    <string name="label_activity">Activity</string>
+    <string name="label_url_scheme">URL Scheme</string>
+    <string name="label_xiaobu_shortcut_id">小布快捷指令ID</string>
+    <string name="label_shell_command">Shell命令</string>
+    <string name="label_vibrate_feedback">是否震动反馈</string>
+    <string name="label_execute_when_screen_off">息屏状态下是否执行操作</string>
+    <string name="action_save">保存设置</string>
+    <string name="action_authorize">去授权</string>
+    <string name="action_confirm">确定</string>
+    <string name="hint_package_name">例如：com.coolapk.market</string>
+    <string name="hint_activity">例如：com.coolapk.market.view.search.SuperSearchActivity</string>
+    <string name="hint_url_scheme">例如：weixin://</string>
+    <string name="hint_xiaobu_shortcut_id">抓取ID后，粘贴在这里</string>
+    <string name="hint_shell_command">输入要执行的命令</string>
+    <string name="message_activate_module_first">请先激活模块</string>
+    <string name="message_saved">已保存（3 秒后生效）</string>
+    <string name="message_root_granted">已被授予Root权限</string>
+    <string name="message_root_denied">已被拒绝Root权限，无法执行Shell命令</string>
+    <string name="dialog_title_notice">提示</string>
+    <string name="dialog_shell_permission_message">由于系统限制，执行Shell命令需要Root权限和自启动权限，否则无法执行。\n应用只会在执行命令的瞬间启动，执行完毕后自动退出，不会占用后台内存。\n在某些情况下，你可能还需要在应用详情的耗电管理中完全允许后台行为。</string>
 </resources>


### PR DESCRIPTION
## Summary
- Move the settings screen's hardcoded Chinese labels, hints, arrays, toast messages, and shell permission dialog text into Android resources.
- Add English and Korean resource variants for the existing settings UI.
- Store stable Chinese action values internally so saved configurations do not depend on the current display locale.

## Validation
- ANDROID_HOME=/Users/yeowool/Library/Android/sdk gradle assembleDebug