### PR TITLE
Add custom Activity support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.VIBRATE" />
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
+++ b/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
@@ -1,25 +1,75 @@
 package me.siowu.OplusKeyHook;
 
 import android.app.AlertDialog;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
-import android.widget.*;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 
 import me.siowu.OplusKeyHook.utils.SPUtils;
 
 public class MainActivity extends AppCompatActivity {
 
-    private Spinner spinnerGesture, spinnerType, spinnerCommon;
-    private EditText editPackage, editActivity, editUrlScheme, editxiaobuShortcuts, editShell;
-    private LinearLayout layoutCommon, layoutCustomActivity, layoutUrlScheme, layoutxiaobuShortcuts, layoutShell;
+    private static final String TYPE_NONE = "none";
+    private static final String TYPE_COMMON = "common";
+    private static final String TYPE_XIAOBU_SHORTCUT = "xiaobu_shortcut";
+    private static final String TYPE_CUSTOM_ACTIVITY = "custom_activity";
+    private static final String TYPE_CUSTOM_URL_SCHEME = "custom_url_scheme";
+    private static final String TYPE_CUSTOM_SHELL = "custom_shell";
+
+    private Spinner spinnerGesture;
+    private Spinner spinnerType;
+    private Spinner spinnerCommon;
+    private Spinner spinnerApp;
+    private Spinner spinnerActivity;
+    private EditText editUrlScheme;
+    private EditText editxiaobuShortcuts;
+    private EditText editShell;
+    private TextView textSelectedPackage;
+    private TextView textSelectedActivity;
+    private LinearLayout layoutCommon;
+    private LinearLayout layoutCustomActivity;
+    private LinearLayout layoutUrlScheme;
+    private LinearLayout layoutxiaobuShortcuts;
+    private LinearLayout layoutShell;
     private Button btnSave;
-    private CheckBox checkboxVibrate, checkboxExecuteWhenScreenOff;
+    private CheckBox checkboxVibrate;
+    private CheckBox checkboxExecuteWhenScreenOff;
+
+    private final List<AppOption> appOptions = new ArrayList<>();
+    private final List<ActivityOption> activityOptions = new ArrayList<>();
+    private ArrayAdapter<String> appAdapter;
+    private ArrayAdapter<String> activityAdapter;
+
+    private String selectedPackageName = "";
+    private String selectedActivityName = "";
+    private boolean suppressNextAppSelectionEvent = false;
+    private boolean suppressNextActivitySelectionEvent = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -29,23 +79,23 @@ public class MainActivity extends AppCompatActivity {
         try {
             SPUtils.init(this);
         } catch (SecurityException e) {
-            runOnUiThread(() -> {
-                Toast.makeText(
-                        MainActivity.this,
-                        "请先激活模块",
-                        Toast.LENGTH_LONG
-                ).show();
-            });
+            runOnUiThread(() -> Toast.makeText(
+                    MainActivity.this,
+                    R.string.message_activate_module_first,
+                    Toast.LENGTH_LONG
+            ).show());
         }
 
-        spinnerGesture = findViewById(R.id.spinnerGesture); // ⬅ 新增手势选择控件
+        spinnerGesture = findViewById(R.id.spinnerGesture);
         spinnerType = findViewById(R.id.spinnerType);
         spinnerCommon = findViewById(R.id.spinnerCommon);
-        editPackage = findViewById(R.id.editPackage);
-        editActivity = findViewById(R.id.editActivity);
+        spinnerApp = findViewById(R.id.spinnerApp);
+        spinnerActivity = findViewById(R.id.spinnerActivity);
         editUrlScheme = findViewById(R.id.editUrlScheme);
         editxiaobuShortcuts = findViewById(R.id.editxiaobuShortcuts);
         editShell = findViewById(R.id.editShell);
+        textSelectedPackage = findViewById(R.id.textSelectedPackage);
+        textSelectedActivity = findViewById(R.id.textSelectedActivity);
         layoutCommon = findViewById(R.id.layoutCommon);
         layoutCustomActivity = findViewById(R.id.layoutCustomActivity);
         layoutUrlScheme = findViewById(R.id.layoutUrlScheme);
@@ -55,30 +105,9 @@ public class MainActivity extends AppCompatActivity {
         checkboxExecuteWhenScreenOff = findViewById(R.id.checkboxExecuteWhenScreenOff);
         btnSave = findViewById(R.id.btnSave);
 
-        // 手势选择
-        ArrayAdapter<String> adapterGesture = new ArrayAdapter<>(
-                this, android.R.layout.simple_spinner_item,
-                new String[]{"短按", "双击", "长按"}
-        );
-        adapterGesture.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinnerGesture.setAdapter(adapterGesture);
+        setupStaticSpinners();
+        setupCustomActivitySpinners();
 
-        // 类型选择
-        ArrayAdapter<String> adapterType = new ArrayAdapter<>(
-                this, android.R.layout.simple_spinner_item,
-                new String[]{"无", "常用功能", "执行小布快捷指令", "自定义Activity", "自定义UrlScheme", "自定义Shell命令"}
-        );
-        adapterType.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinnerType.setAdapter(adapterType);
-
-        ArrayAdapter<String> adapterCommon = new ArrayAdapter<>(
-                this, android.R.layout.simple_spinner_item,
-                new String[]{"微信付款码", "微信扫一扫", "支付宝付款码", "支付宝扫一扫", "云闪付付款码", "云闪付扫一扫", "一键闪记", "小布记忆"}
-        );
-        adapterCommon.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        spinnerCommon.setAdapter(adapterCommon);
-
-        // 当选择不同手势时加载不同配置
         spinnerGesture.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
@@ -103,17 +132,122 @@ public class MainActivity extends AppCompatActivity {
 
         btnSave.setOnClickListener(v -> saveConfig());
 
-        loadGestureConfig(0); // 默认加载【短按】
+        loadInstalledApps();
+        loadGestureConfig(0);
+    }
+
+    private void setupStaticSpinners() {
+        ArrayAdapter<String> adapterGesture = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.gesture_options)))
+        );
+        adapterGesture.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerGesture.setAdapter(adapterGesture);
+
+        ArrayAdapter<String> adapterType = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.type_options)))
+        );
+        adapterType.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerType.setAdapter(adapterType);
+
+        ArrayAdapter<String> adapterCommon = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.common_action_options)))
+        );
+        adapterCommon.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        spinnerCommon.setAdapter(adapterCommon);
+    }
+
+    private void setupCustomActivitySpinners() {
+        appAdapter = createSpinnerAdapter(Collections.singletonList(getString(R.string.loading_apps)));
+        activityAdapter = createSpinnerAdapter(Collections.singletonList(getString(R.string.prompt_select_activity)));
+        spinnerApp.setAdapter(appAdapter);
+        spinnerActivity.setAdapter(activityAdapter);
+
+        spinnerApp.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                if (suppressNextAppSelectionEvent) {
+                    suppressNextAppSelectionEvent = false;
+                    return;
+                }
+
+                if (position <= 0 || position - 1 >= appOptions.size()) {
+                    if (position == 0) {
+                        selectedPackageName = "";
+                        selectedActivityName = "";
+                        updateCustomActivitySummary();
+                        updateActivitySpinner(Collections.singletonList(getString(R.string.prompt_select_activity)));
+                    }
+                    return;
+                }
+
+                AppOption selectedApp = appOptions.get(position - 1);
+                if (!TextUtils.equals(selectedPackageName, selectedApp.packageName)) {
+                    selectedPackageName = selectedApp.packageName;
+                    selectedActivityName = "";
+                    updateCustomActivitySummary();
+                    loadActivitiesForPackage(selectedApp.packageName);
+                } else if (activityOptions.isEmpty()) {
+                    loadActivitiesForPackage(selectedApp.packageName);
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+
+        spinnerActivity.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                if (suppressNextActivitySelectionEvent) {
+                    suppressNextActivitySelectionEvent = false;
+                    return;
+                }
+
+                if (position <= 0 || position - 1 >= activityOptions.size()) {
+                    if (position == 0) {
+                        selectedActivityName = "";
+                        updateCustomActivitySummary();
+                    }
+                    return;
+                }
+
+                selectedActivityName = activityOptions.get(position - 1).className;
+                updateCustomActivitySummary();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
+
+        updateCustomActivitySummary();
+    }
+
+    private ArrayAdapter<String> createSpinnerAdapter(List<String> values) {
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                this,
+                android.R.layout.simple_spinner_item,
+                new ArrayList<>(values)
+        );
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        return adapter;
     }
 
     private void loadGestureConfig(int gesture) {
         String prefix = getPrefix(gesture);
 
-        spinnerType.setSelection(getTypeIndex(SPUtils.getString(prefix + "type", "无")));
+        spinnerType.setSelection(getTypeIndex(SPUtils.getString(prefix + "type", TYPE_NONE)));
         spinnerCommon.setSelection(SPUtils.getInt(prefix + "common_index", 0));
 
-        editPackage.setText(SPUtils.getString(prefix + "package", ""));
-        editActivity.setText(SPUtils.getString(prefix + "activity", ""));
+        selectedPackageName = SPUtils.getString(prefix + "package", "");
+        selectedActivityName = SPUtils.getString(prefix + "activity", "");
         editUrlScheme.setText(SPUtils.getString(prefix + "url", ""));
         editxiaobuShortcuts.setText(SPUtils.getString(prefix + "xiaobu_shortcuts", ""));
         editShell.setText(SPUtils.getString(prefix + "shell", ""));
@@ -121,17 +255,20 @@ public class MainActivity extends AppCompatActivity {
         checkboxVibrate.setChecked(SPUtils.getBoolean(prefix + "vibrate", true));
         checkboxExecuteWhenScreenOff.setChecked(SPUtils.getBoolean(prefix + "screen_off", true));
 
+        updateCustomActivitySummary();
+        restoreAppSelection();
         updateLayout(spinnerType.getSelectedItemPosition());
     }
 
     private void saveConfig() {
         int gesture = spinnerGesture.getSelectedItemPosition();
         String prefix = getPrefix(gesture);
+        String type = getSelectedTypeValue();
 
-        SPUtils.putString(prefix + "type", (String) spinnerType.getSelectedItem());
+        SPUtils.putString(prefix + "type", type);
         SPUtils.putInt(prefix + "common_index", spinnerCommon.getSelectedItemPosition());
-        SPUtils.putString(prefix + "package", editPackage.getText().toString().trim());
-        SPUtils.putString(prefix + "activity", editActivity.getText().toString().trim());
+        SPUtils.putString(prefix + "package", selectedPackageName.trim());
+        SPUtils.putString(prefix + "activity", selectedActivityName.trim());
         SPUtils.putString(prefix + "url", editUrlScheme.getText().toString().trim());
         SPUtils.putString(prefix + "xiaobu_shortcuts", editxiaobuShortcuts.getText().toString().trim());
         SPUtils.putString(prefix + "shell", editShell.getText().toString().trim());
@@ -139,48 +276,290 @@ public class MainActivity extends AppCompatActivity {
         SPUtils.putBoolean(prefix + "vibrate", checkboxVibrate.isChecked());
         SPUtils.putBoolean(prefix + "screen_off", checkboxExecuteWhenScreenOff.isChecked());
 
-        Toast.makeText(this, "已保存（3 秒后生效）", Toast.LENGTH_SHORT).show();
+        Toast.makeText(this, R.string.message_saved, Toast.LENGTH_SHORT).show();
 
-        String type = (String) spinnerType.getSelectedItem();
-        if (type.equals("自定义Shell命令")) {
+        if (TYPE_CUSTOM_SHELL.equals(type)) {
             if (applyRootPermission()) {
-                Toast.makeText(this, "已被授予Root权限", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.message_root_granted, Toast.LENGTH_SHORT).show();
             } else {
-                Toast.makeText(this, "已被拒绝Root权限，无法执行Shell命令", Toast.LENGTH_SHORT).show();
+                Toast.makeText(this, R.string.message_root_denied, Toast.LENGTH_SHORT).show();
             }
             showShellPermissionDialog();
         }
+    }
 
+    private void loadInstalledApps() {
+        updateAppSpinner(Collections.singletonList(getString(R.string.loading_apps)));
+        new Thread(() -> {
+            List<AppOption> options = new ArrayList<>();
+            PackageManager packageManager = getPackageManager();
+            Collator collator = Collator.getInstance(Locale.getDefault());
+
+            try {
+                List<ApplicationInfo> applications = getInstalledApplicationsCompat(packageManager);
+                for (ApplicationInfo applicationInfo : applications) {
+                    String packageName = applicationInfo.packageName;
+                    String label = packageManager.getApplicationLabel(applicationInfo).toString().trim();
+                    if (label.isEmpty()) {
+                        label = packageName;
+                    }
+                    options.add(new AppOption(label, packageName));
+                }
+            } catch (Exception e) {
+                Log.e("MainActivity", "loadInstalledApps", e);
+            }
+
+            options.sort((left, right) -> {
+                int labelResult = collator.compare(left.label, right.label);
+                if (labelResult != 0) {
+                    return labelResult;
+                }
+                return collator.compare(left.packageName, right.packageName);
+            });
+
+            runOnUiThread(() -> {
+                appOptions.clear();
+                appOptions.addAll(options);
+                updateAppSpinner(buildAppEntries(options));
+                restoreAppSelection();
+            });
+        }).start();
+    }
+
+    private void loadActivitiesForPackage(String packageName) {
+        if (TextUtils.isEmpty(packageName)) {
+            activityOptions.clear();
+            updateActivitySpinner(Collections.singletonList(getString(R.string.prompt_select_activity)));
+            return;
+        }
+
+        updateActivitySpinner(Collections.singletonList(getString(R.string.loading_activities)));
+        new Thread(() -> {
+            List<ActivityOption> options = new ArrayList<>();
+            PackageManager packageManager = getPackageManager();
+            Collator collator = Collator.getInstance(Locale.getDefault());
+
+            try {
+                PackageInfo packageInfo = getPackageInfoCompat(packageManager, packageName);
+                if (packageInfo.activities != null) {
+                    for (ActivityInfo activityInfo : packageInfo.activities) {
+                        String className = normalizeClassName(activityInfo.packageName, activityInfo.name);
+                        CharSequence label = activityInfo.loadLabel(packageManager);
+                        String displayName = buildActivityLabel(label, className);
+                        options.add(new ActivityOption(displayName, className));
+                    }
+                }
+            } catch (Exception e) {
+                Log.e("MainActivity", "loadActivitiesForPackage", e);
+            }
+
+            options.sort((left, right) -> {
+                int labelResult = collator.compare(left.label, right.label);
+                if (labelResult != 0) {
+                    return labelResult;
+                }
+                return collator.compare(left.className, right.className);
+            });
+
+            runOnUiThread(() -> {
+                if (!TextUtils.equals(selectedPackageName, packageName)) {
+                    return;
+                }
+
+                activityOptions.clear();
+                activityOptions.addAll(options);
+                updateActivitySpinner(buildActivityEntries(options));
+                restoreActivitySelection();
+            });
+        }).start();
+    }
+
+    private List<ApplicationInfo> getInstalledApplicationsCompat(PackageManager packageManager) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return packageManager.getInstalledApplications(PackageManager.ApplicationInfoFlags.of(0));
+        }
+        return packageManager.getInstalledApplications(0);
+    }
+
+    private PackageInfo getPackageInfoCompat(PackageManager packageManager, String packageName) throws PackageManager.NameNotFoundException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(PackageManager.GET_ACTIVITIES));
+        }
+        return packageManager.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
+    }
+
+    private void restoreAppSelection() {
+        if (appAdapter == null) {
+            return;
+        }
+
+        int selection = 0;
+        if (!TextUtils.isEmpty(selectedPackageName)) {
+            for (int i = 0; i < appOptions.size(); i++) {
+                if (TextUtils.equals(appOptions.get(i).packageName, selectedPackageName)) {
+                    selection = i + 1;
+                    break;
+                }
+            }
+        }
+
+        if (spinnerApp.getSelectedItemPosition() != selection) {
+            suppressNextAppSelectionEvent = true;
+            spinnerApp.setSelection(selection);
+            if (selection > 0 || !TextUtils.isEmpty(selectedPackageName)) {
+                loadActivitiesForPackage(selectedPackageName);
+            } else {
+                activityOptions.clear();
+                updateActivitySpinner(Collections.singletonList(getString(R.string.prompt_select_activity)));
+            }
+        } else if (selection > 0) {
+            loadActivitiesForPackage(selectedPackageName);
+        } else if (!TextUtils.isEmpty(selectedPackageName)) {
+            loadActivitiesForPackage(selectedPackageName);
+        } else {
+            activityOptions.clear();
+            updateActivitySpinner(Collections.singletonList(getString(R.string.prompt_select_activity)));
+        }
+    }
+
+    private void restoreActivitySelection() {
+        int selection = 0;
+        if (!TextUtils.isEmpty(selectedActivityName)) {
+            for (int i = 0; i < activityOptions.size(); i++) {
+                if (TextUtils.equals(activityOptions.get(i).className, selectedActivityName)) {
+                    selection = i + 1;
+                    break;
+                }
+            }
+        }
+
+        if (spinnerActivity.getSelectedItemPosition() != selection) {
+            suppressNextActivitySelectionEvent = true;
+            spinnerActivity.setSelection(selection);
+        } else {
+            updateCustomActivitySummary();
+        }
+    }
+
+    private void updateAppSpinner(List<String> items) {
+        replaceAdapterItems(appAdapter, items);
+    }
+
+    private void updateActivitySpinner(List<String> items) {
+        replaceAdapterItems(activityAdapter, items);
+    }
+
+    private void replaceAdapterItems(ArrayAdapter<String> adapter, List<String> items) {
+        adapter.clear();
+        adapter.addAll(items);
+        adapter.notifyDataSetChanged();
+    }
+
+    private List<String> buildAppEntries(List<AppOption> options) {
+        List<String> items = new ArrayList<>();
+        items.add(getString(R.string.prompt_select_app));
+        if (options.isEmpty()) {
+            items.set(0, getString(R.string.no_apps_found));
+            return items;
+        }
+        for (AppOption option : options) {
+            items.add(option.label + " (" + option.packageName + ")");
+        }
+        return items;
+    }
+
+    private List<String> buildActivityEntries(List<ActivityOption> options) {
+        List<String> items = new ArrayList<>();
+        items.add(getString(R.string.prompt_select_activity));
+        if (options.isEmpty()) {
+            items.set(0, getString(R.string.no_activities_found));
+            return items;
+        }
+        for (ActivityOption option : options) {
+            items.add(option.label);
+        }
+        return items;
+    }
+
+    private String buildActivityLabel(CharSequence label, String className) {
+        String cleanLabel = label == null ? "" : label.toString().trim();
+        if (cleanLabel.isEmpty() || TextUtils.equals(cleanLabel, className)) {
+            return className;
+        }
+        return cleanLabel + " (" + className + ")";
+    }
+
+    private String normalizeClassName(String packageName, String className) {
+        if (TextUtils.isEmpty(className)) {
+            return "";
+        }
+        if (className.startsWith(".")) {
+            return packageName + className;
+        }
+        return className;
+    }
+
+    private void updateCustomActivitySummary() {
+        textSelectedPackage.setText(TextUtils.isEmpty(selectedPackageName)
+                ? getString(R.string.not_selected)
+                : selectedPackageName);
+        textSelectedActivity.setText(TextUtils.isEmpty(selectedActivityName)
+                ? getString(R.string.not_selected)
+                : selectedActivityName);
     }
 
     private String getPrefix(int gesture) {
         switch (gesture) {
             case 0:
-                return "single_"; // 短按
+                return "single_";
             case 1:
-                return "double_"; // 双击
+                return "double_";
             case 2:
-                return "long_";   // 长按
+                return "long_";
+            default:
+                return "single_";
         }
-        return "single_";
     }
 
     private int getTypeIndex(String type) {
         switch (type) {
+            case TYPE_NONE:
             case "无":
                 return 0;
+            case TYPE_COMMON:
             case "常用功能":
                 return 1;
+            case TYPE_XIAOBU_SHORTCUT:
             case "执行小布快捷指令":
                 return 2;
+            case TYPE_CUSTOM_ACTIVITY:
             case "自定义Activity":
                 return 3;
+            case TYPE_CUSTOM_URL_SCHEME:
             case "自定义UrlScheme":
                 return 4;
+            case TYPE_CUSTOM_SHELL:
             case "自定义Shell命令":
                 return 5;
             default:
                 return 0;
+        }
+    }
+
+    private String getSelectedTypeValue() {
+        switch (spinnerType.getSelectedItemPosition()) {
+            case 1:
+                return TYPE_COMMON;
+            case 2:
+                return TYPE_XIAOBU_SHORTCUT;
+            case 3:
+                return TYPE_CUSTOM_ACTIVITY;
+            case 4:
+                return TYPE_CUSTOM_URL_SCHEME;
+            case 5:
+                return TYPE_CUSTOM_SHELL;
+            default:
+                return TYPE_NONE;
         }
     }
 
@@ -207,34 +586,34 @@ public class MainActivity extends AppCompatActivity {
             case 5:
                 layoutShell.setVisibility(View.VISIBLE);
                 break;
+            default:
+                break;
         }
     }
 
     public boolean applyRootPermission() {
         Process process = null;
         try {
-            // 测试执行一条简单命令
             process = Runtime.getRuntime().exec("su -c echo root_ok");
             BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String result = br.readLine();
-            return "root_ok".equals(result);  // 成功执行
+            return "root_ok".equals(result);
         } catch (Exception e) {
             return false;
         } finally {
-            if (process != null) process.destroy();
+            if (process != null) {
+                process.destroy();
+            }
         }
     }
 
     private void showShellPermissionDialog() {
         new AlertDialog.Builder(this)
-                .setTitle("提示")
-                .setMessage("由于系统限制，执行Shell命令需要Root权限和自启动权限，否则无法执行。\n应用只会在执行命令的瞬间启动，执行完毕后自动退出，不会占用后台内存。\n在某些情况下，你可能还需要在应用详情的耗电管理中完全允许后台行为。")
+                .setTitle(R.string.dialog_title_notice)
+                .setMessage(R.string.dialog_shell_permission_message)
                 .setCancelable(false)
-                .setNegativeButton("去授权", (dialog, which) -> {
-                    // 继续执行跳转逻辑
-                    gotoColorOSAutoStart();        // 自启动管理
-                })
-                .setPositiveButton("确定", null)
+                .setNegativeButton(R.string.action_authorize, (dialog, which) -> gotoColorOSAutoStart())
+                .setPositiveButton(R.string.action_confirm, null)
                 .show();
     }
 
@@ -249,5 +628,23 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    private static final class AppOption {
+        private final String label;
+        private final String packageName;
 
+        private AppOption(String label, String packageName) {
+            this.label = label;
+            this.packageName = packageName;
+        }
+    }
+
+    private static final class ActivityOption {
+        private final String label;
+        private final String className;
+
+        private ActivityOption(String label, String className) {
+            this.label = label;
+            this.className = className;
+        }
+    }
 }

--- a/app/src/main/java/me/siowu/OplusKeyHook/hooks/KeyHook.java
+++ b/app/src/main/java/me/siowu/OplusKeyHook/hooks/KeyHook.java
@@ -150,21 +150,27 @@ public class KeyHook {
         String type = sp.getString(prefix + "type", "");
         XposedBridge.log("当前快捷键类型: " + type);
         switch (type) {
+            case "none":
             case "无":
                 XposedBridge.log("不执行任何操作");
                 break;
+            case "common":
             case "常用功能":
                 doCommonAction(prefix);
                 break;
+            case "custom_activity":
             case "自定义Activity":
                 doCustomActivity(prefix);
                 break;
+            case "custom_url_scheme":
             case "自定义UrlScheme":
                 doCustomUrlScheme(prefix);
                 break;
+            case "xiaobu_shortcut":
             case "执行小布快捷指令":
                 doXiaobuShortcuts(prefix);
                 break;
+            case "custom_shell":
             case "自定义Shell命令":
                 doCustomShell(prefix);
                 break;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
             android:layout_marginBottom="8dp"
-            android:text="选择事件类型"
+            android:text="@string/label_gesture"
             android:textSize="16sp" />
 
         <Spinner
@@ -27,7 +27,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="8dp"
-            android:text="选择快捷键功能"
+            android:text="@string/label_function"
             android:textSize="16sp" />
 
         <Spinner
@@ -47,7 +47,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="选择常用功能" />
+                android:text="@string/label_common_action" />
 
             <Spinner
                 android:id="@+id/spinnerCommon"
@@ -67,25 +67,55 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="包名" />
+                android:text="@string/label_app" />
 
-            <EditText
-                android:id="@+id/editPackage"
+            <Spinner
+                android:id="@+id/spinnerApp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：com.coolapk.market" />
+                android:spinnerMode="dialog" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                android:text="Activity" />
+                android:text="@string/label_activity" />
 
-            <EditText
-                android:id="@+id/editActivity"
+            <Spinner
+                android:id="@+id/spinnerActivity"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：com.coolapk.market.view.search.SuperSearchActivity" />
+                android:spinnerMode="dialog" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/label_selected_package" />
+
+            <TextView
+                android:id="@+id/textSelectedPackage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/not_selected"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="12sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/label_selected_activity" />
+
+            <TextView
+                android:id="@+id/textSelectedActivity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/not_selected"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="12sp" />
         </LinearLayout>
 
         <!-- 自定义 URL Scheme -->
@@ -100,13 +130,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="URL Scheme" />
+                android:text="@string/label_url_scheme" />
 
             <EditText
                 android:id="@+id/editUrlScheme"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="例如：weixin://" />
+                android:hint="@string/hint_url_scheme" />
         </LinearLayout>
 
         <!-- 快捷指令ID -->
@@ -121,13 +151,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="小布快捷指令ID" />
+                android:text="@string/label_xiaobu_shortcut_id" />
 
             <EditText
                 android:id="@+id/editxiaobuShortcuts"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="抓取ID后，粘贴在这里" />
+                android:hint="@string/hint_xiaobu_shortcut_id" />
         </LinearLayout>
 
         <!-- 快捷指令ID -->
@@ -142,13 +172,13 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Shell命令" />
+                android:text="@string/label_shell_command" />
 
             <EditText
                 android:id="@+id/editShell"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="输入要执行的命令" />
+                android:hint="@string/hint_shell_command" />
         </LinearLayout>
 
         <CheckBox
@@ -157,7 +187,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="20dp"
             android:checked="true"
-            android:text="是否震动反馈" />
+            android:text="@string/label_vibrate_feedback" />
 
         <CheckBox
             android:id="@+id/checkboxExecuteWhenScreenOff"
@@ -165,13 +195,13 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="0dp"
             android:checked="true"
-            android:text="息屏状态下是否执行操作" />
+            android:text="@string/label_execute_when_screen_off" />
 
         <Button
             android:id="@+id/btnSave"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="24dp"
-            android:text="保存设置" />
+            android:text="@string/action_save" />
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -4,4 +4,30 @@
         <item>android</item>
         <item>com.coloros.shortcuts</item>
     </string-array>
+
+    <string-array name="gesture_options">
+        <item>短按</item>
+        <item>双击</item>
+        <item>长按</item>
+    </string-array>
+
+    <string-array name="type_options">
+        <item>无</item>
+        <item>常用功能</item>
+        <item>执行小布快捷指令</item>
+        <item>自定义Activity</item>
+        <item>自定义UrlScheme</item>
+        <item>自定义Shell命令</item>
+    </string-array>
+
+    <string-array name="common_action_options">
+        <item>微信付款码</item>
+        <item>微信扫一扫</item>
+        <item>支付宝付款码</item>
+        <item>支付宝扫一扫</item>
+        <item>云闪付付款码</item>
+        <item>云闪付扫一扫</item>
+        <item>一键闪记</item>
+        <item>小布记忆</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,34 @@
 <resources>
     <string name="app_name">快捷键自定义</string>
+    <string name="label_gesture">选择事件类型</string>
+    <string name="label_function">选择快捷键功能</string>
+    <string name="label_common_action">选择常用功能</string>
+    <string name="label_app">选择应用</string>
+    <string name="label_activity">选择 Activity</string>
+    <string name="label_selected_package">已选包名</string>
+    <string name="label_selected_activity">已选 Activity</string>
+    <string name="label_url_scheme">URL Scheme</string>
+    <string name="label_xiaobu_shortcut_id">小布快捷指令 ID</string>
+    <string name="label_shell_command">Shell 命令</string>
+    <string name="label_vibrate_feedback">是否震动反馈</string>
+    <string name="label_execute_when_screen_off">息屏状态下是否执行操作</string>
+    <string name="action_save">保存设置</string>
+    <string name="hint_url_scheme">例如：weixin://</string>
+    <string name="hint_xiaobu_shortcut_id">抓取 ID 后，粘贴在这里</string>
+    <string name="hint_shell_command">输入要执行的命令</string>
+    <string name="message_activate_module_first">请先激活模块</string>
+    <string name="message_saved">已保存（3 秒后生效）</string>
+    <string name="message_root_granted">已被授予 Root 权限</string>
+    <string name="message_root_denied">已被拒绝 Root 权限，无法执行 Shell 命令</string>
+    <string name="dialog_title_notice">提示</string>
+    <string name="dialog_shell_permission_message">由于系统限制，执行 Shell 命令需要 Root 权限和自启动权限，否则无法执行。\n应用只会在执行命令的瞬间启动，执行完毕后自动退出，不会占用后台内存。\n在某些情况下，你可能还需要在应用详情的耗电管理中完全允许后台行为。</string>
+    <string name="action_authorize">去授权</string>
+    <string name="action_confirm">确定</string>
+    <string name="prompt_select_app">请选择应用</string>
+    <string name="prompt_select_activity">请选择 Activity</string>
+    <string name="loading_apps">正在扫描应用列表…</string>
+    <string name="loading_activities">正在扫描 Activity 列表…</string>
+    <string name="no_apps_found">未找到可用应用</string>
+    <string name="no_activities_found">未找到可用 Activity</string>
+    <string name="not_selected">未选择</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add custom Activity as a shortcut action option.
- Persist package and Activity class names per gesture.
- Launch the selected Activity from the key hook and add manifest package visibility for activity discovery/launching.

## Notes
- This PR intentionally excludes the English/Korean locale resource variants from the localization PR.

## Validation
- ANDROID_HOME=/Users/yeowool/Library/Android/sdk gradle assembleDebug