### PR TITLE
Add open-app action

### DIFF
--- a/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
+++ b/app/src/main/java/me/siowu/OplusKeyHook/MainActivity.java
@@ -66,7 +66,7 @@ public class MainActivity extends AppCompatActivity {
         // 类型选择
         ArrayAdapter<String> adapterType = new ArrayAdapter<>(
                 this, android.R.layout.simple_spinner_item,
-                new String[]{"无", "常用功能", "执行小布快捷指令", "自定义Activity", "自定义UrlScheme", "自定义Shell命令"}
+                new String[]{"无", "常用功能", "打开应用", "执行小布快捷指令", "自定义Activity", "自定义UrlScheme", "自定义Shell命令"}
         );
         adapterType.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         spinnerType.setAdapter(adapterType);
@@ -171,14 +171,16 @@ public class MainActivity extends AppCompatActivity {
                 return 0;
             case "常用功能":
                 return 1;
-            case "执行小布快捷指令":
+            case "打开应用":
                 return 2;
-            case "自定义Activity":
+            case "执行小布快捷指令":
                 return 3;
-            case "自定义UrlScheme":
+            case "自定义Activity":
                 return 4;
-            case "自定义Shell命令":
+            case "自定义UrlScheme":
                 return 5;
+            case "自定义Shell命令":
+                return 6;
             default:
                 return 0;
         }
@@ -196,15 +198,18 @@ public class MainActivity extends AppCompatActivity {
                 layoutCommon.setVisibility(View.VISIBLE);
                 break;
             case 2:
-                layoutxiaobuShortcuts.setVisibility(View.VISIBLE);
-                break;
-            case 3:
                 layoutCustomActivity.setVisibility(View.VISIBLE);
                 break;
+            case 3:
+                layoutxiaobuShortcuts.setVisibility(View.VISIBLE);
+                break;
             case 4:
-                layoutUrlScheme.setVisibility(View.VISIBLE);
+                layoutCustomActivity.setVisibility(View.VISIBLE);
                 break;
             case 5:
+                layoutUrlScheme.setVisibility(View.VISIBLE);
+                break;
+            case 6:
                 layoutShell.setVisibility(View.VISIBLE);
                 break;
         }

--- a/app/src/main/java/me/siowu/OplusKeyHook/hooks/KeyHook.java
+++ b/app/src/main/java/me/siowu/OplusKeyHook/hooks/KeyHook.java
@@ -4,6 +4,7 @@ import android.app.PendingIntent;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
@@ -156,6 +157,9 @@ public class KeyHook {
             case "常用功能":
                 doCommonAction(prefix);
                 break;
+            case "打开应用":
+                doOpenApp(prefix);
+                break;
             case "自定义Activity":
                 doCustomActivity(prefix);
                 break;
@@ -215,6 +219,41 @@ public class KeyHook {
             return;
         }
         startActivity(packageName, activity);
+    }
+
+    public void doOpenApp(String prefix) {
+        sp.reload();
+        String packageName = sp.getString(prefix + "package", "");
+        if (packageName.isEmpty()) {
+            XposedBridge.log("打开应用包名为空");
+            return;
+        }
+        startPackage(packageName);
+    }
+
+    private void startPackage(String packageName) {
+        try {
+            Context systemContext = (Context) XposedHelpers.callStaticMethod(
+                    XposedHelpers.findClass("android.app.ActivityThread", null),
+                    "currentApplication"
+            );
+            if (systemContext == null) {
+                XposedBridge.log("startPackage: systemContext == null");
+                return;
+            }
+
+            PackageManager pm = systemContext.getPackageManager();
+            Intent intent = pm.getLaunchIntentForPackage(packageName);
+            if (intent == null) {
+                XposedBridge.log("startPackage: launch intent not found for " + packageName);
+                return;
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            systemContext.startActivity(intent);
+            XposedBridge.log("成功打开应用: " + packageName);
+        } catch (Throwable t) {
+            XposedBridge.log("打开应用失败: " + t.getMessage());
+        }
     }
 
     public void doCustomUrlScheme(String prefix) {


### PR DESCRIPTION
## Summary
- Add an action type for opening an installed app by package name.
- Persist the selected package through the existing package field.
- Launch the package's default launch intent from the key hook.

## Notes
- This keeps the upstream UI simple and reuses the existing package field. The picker/search UX is split into a separate PR.

## Validation
- ANDROID_HOME=/Users/yeowool/Library/Android/sdk gradle assembleDebug